### PR TITLE
IANA Bash Guru but... Some tweaks needed to the /opt/utilities/bin/serialnumber script

### DIFF
--- a/bin/serialnumber
+++ b/bin/serialnumber
@@ -1,9 +1,4 @@
 #!/bin/bash
-_getSerBBW()
-{
-   local serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/eeprom | sed 's/^.* //' | sed -e 's/[.]//g'`
-   echo $serial > /etc/opt/ninja/serial.conf
-}
 if [ -f /etc/environment.local ]; then
         . /etc/environment.local
 fi
@@ -13,9 +8,8 @@ if [[ -z $NINJA_HARDWARE_TYPE ]]; then
 fi
 if [[ -n $NINJA_HARDWARE_TYPE ]]; then
         if [ "$NINJA_HARDWARE_TYPE" == "BBW" ]; then
-				_getSerBBW
-#		        local serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/eeprom | sed 's/^.* //' | sed -e 's/[.]//g'`
-#		        echo $serial > /etc/opt/ninja/serial.conf
+		        local serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/eeprom | sed 's/^.* //' | sed -e 's/[.]//g'`
+		        echo $serial > /etc/opt/ninja/serial.conf
         elif [ "$NINJA_HARDWARE_TYPE" == "BBB" ]; then
                 cat /sys/devices/bone_capemgr.9/baseboard/serial-number > /etc/opt/ninja/serial.conf
         fi

--- a/bin/serialnumber
+++ b/bin/serialnumber
@@ -1,4 +1,9 @@
 #!/bin/bash
+_getSerBBW()
+{
+   local serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/e$
+   echo $serial > /etc/opt/ninja/serial.conf
+}
 if [ -f /etc/environment.local ]; then
         . /etc/environment.local
 fi
@@ -8,8 +13,9 @@ if [[ -z $NINJA_HARDWARE_TYPE ]]; then
 fi
 if [[ -n $NINJA_HARDWARE_TYPE ]]; then
         if [ "$NINJA_HARDWARE_TYPE" == "BBW" ]; then
-		        local serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/eeprom | sed 's/^.* //' | sed -e 's/[.]//g'`
-		        echo $serial > /etc/opt/ninja/serial.conf
+				_getSerBBW
+#		        local serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/eeprom | sed 's/^.* //' | sed -e 's/[.]//g'`
+#		        echo $serial > /etc/opt/ninja/serial.conf
         elif [ "$NINJA_HARDWARE_TYPE" == "BBB" ]; then
                 cat /sys/devices/bone_capemgr.9/baseboard/serial-number > /etc/opt/ninja/serial.conf
         fi

--- a/bin/serialnumber
+++ b/bin/serialnumber
@@ -1,7 +1,7 @@
 #!/bin/bash
 _getSerBBW()
 {
-   local serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/e$
+   local serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/eeprom | sed 's/^.* //' | sed -e 's/[.]//g'`
    echo $serial > /etc/opt/ninja/serial.conf
 }
 if [ -f /etc/environment.local ]; then

--- a/bin/serialnumber
+++ b/bin/serialnumber
@@ -1,4 +1,9 @@
 #!/bin/bash
+_getSerBBW()
+{
+   local serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/eeprom | sed 's/^.* //' | sed -e 's/[.]//g'`
+   echo $serial > /etc/opt/ninja/serial.conf
+}
 if [ -f /etc/environment.local ]; then
         . /etc/environment.local
 fi
@@ -8,8 +13,7 @@ if [[ -z $NINJA_HARDWARE_TYPE ]]; then
 fi
 if [[ -n $NINJA_HARDWARE_TYPE ]]; then
         if [ "$NINJA_HARDWARE_TYPE" == "BBW" ]; then
-		        local serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/eeprom | sed 's/^.* //' | sed -e 's/[.]//g'`
-		        echo $serial > /etc/opt/ninja/serial.conf
+				_getSerBBW
         elif [ "$NINJA_HARDWARE_TYPE" == "BBB" ]; then
                 cat /sys/devices/bone_capemgr.9/baseboard/serial-number > /etc/opt/ninja/serial.conf
         fi


### PR DESCRIPTION
IANA Bash Guru but...
Here's some tweaks that appear to fix the following issue with serialnumber:

/opt/utilities/bin/serialnumber
/opt/utilities/bin/serialnumber: line 11: local: can only be used in a function

Apologies that the merge may be munged, first pull request I've made on Github.
Standard disclaimer applies, works on my block ;)
