### PR TITLE
Fixes so the scripts work on a 4.1 kernel

### DIFF
--- a/bin/detect-hw-os
+++ b/bin/detect-hw-os
@@ -17,7 +17,7 @@ if [[ ${NINJA_CLIENT_NAME} = "pi" ]]; then
 else # beaglebone
 	echo "export NINJA_CAPE_V121_RESETGPIO=44" >> /etc/environment.local
 	echo "export NINJA_CAPE_DETECT_GPIO=60" >> /etc/environment.local
-	dmesg | grep -q "Bone-Black-HDMI"
+	dmesg | grep -q -i "beaglebone-black"
 	if [ "$?" == 0 ]; then
 		echo "export NINJA_HARDWARE_TYPE=BBB" >> /etc/environment.local
 	else

--- a/bin/serialnumber
+++ b/bin/serialnumber
@@ -11,7 +11,11 @@ if [[ -n $NINJA_HARDWARE_TYPE ]]; then
 		        serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/eeprom | sed 's/^.* //' | sed -e 's/[.]//g'`
 		        echo $serial > /etc/opt/ninja/serial.conf
         elif [ "$NINJA_HARDWARE_TYPE" == "BBB" ]; then
-                cat /sys/devices/bone_capemgr.9/baseboard/serial-number > /etc/opt/ninja/serial.conf
+                capemgr=/sys/devices/bone_capemgr.9
+                if [ ! -d $capemgr ] ; then
+                        capemgr=/sys/devices/platform/bone_capemgr
+                fi
+                cat $capemgr/baseboard/serial-number > /etc/opt/ninja/serial.conf
         fi
 fi
 if [ -f /etc/opt/ninja/serial.override.conf ]; then


### PR DESCRIPTION
`detect-hw-os` and `serialnumber` will otherwise fail on a 4.1 kernel. The changes should maintain function on the original kernel version for which they were written.
