### PR TITLE
Enable Arduino UART if not enabled

### DIFF
--- a/bin/detect-hw-os
+++ b/bin/detect-hw-os
@@ -17,7 +17,7 @@ if [[ ${NINJA_CLIENT_NAME} = "pi" ]]; then
 else # beaglebone
 	echo "export NINJA_CAPE_V121_RESETGPIO=44" >> /etc/environment.local
 	echo "export NINJA_CAPE_DETECT_GPIO=60" >> /etc/environment.local
-	dmesg | grep -q "Bone-Black-HDMI"
+	dmesg | grep -q -i "beaglebone-black"
 	if [ "$?" == 0 ]; then
 		echo "export NINJA_HARDWARE_TYPE=BBB" >> /etc/environment.local
 	else

--- a/bin/serialnumber
+++ b/bin/serialnumber
@@ -11,7 +11,11 @@ if [[ -n $NINJA_HARDWARE_TYPE ]]; then
 		        serial=`sudo xxd -g 2 -a -l 16 -seek 16 /sys/bus/i2c//devices/1-0050/eeprom | sed 's/^.* //' | sed -e 's/[.]//g'`
 		        echo $serial > /etc/opt/ninja/serial.conf
         elif [ "$NINJA_HARDWARE_TYPE" == "BBB" ]; then
-                cat /sys/devices/bone_capemgr.9/baseboard/serial-number > /etc/opt/ninja/serial.conf
+                capemgr=/sys/devices/bone_capemgr.9
+                if [ ! -d $capemgr ] ; then
+                        capemgr=/sys/devices/platform/bone_capemgr
+                fi
+                cat $capemgr/baseboard/serial-number > /etc/opt/ninja/serial.conf
         fi
 fi
 if [ -f /etc/opt/ninja/serial.override.conf ]; then

--- a/init/arduino-uart-enable.conf
+++ b/init/arduino-uart-enable.conf
@@ -1,0 +1,32 @@
+description	"Ensure needed UARTs are enabled"
+author      "Hilmar Lapp <hlapp@drycafe.net>"
+
+start on filesystem and runlevel [2345]
+
+task
+
+script
+    if [ -z "$ARDUINO_UART" ] ; then
+        ARDUINO_UART=1
+    fi
+    if [ ! -c /dev/ttyO$ARDUINO_UART ] ; then
+        . /etc/default/rcS
+        if [ "$NINJA_HARDWARE_TYPE" == "BBB" ]; then
+            capemgr=/sys/devices/bone_capemgr.9
+            if [ ! -d $capemgr ] ; then
+                capemgr=/sys/devices/platform/bone_capemgr
+            fi
+            exec echo "BB-UART$ARDUINO_UART" > $capemgr/slots
+        fi
+    fi
+end script
+
+pre-start script
+    if [ -f /etc/environment.local ]; then
+        . /etc/environment.local
+    fi
+    if [[ -z $NINJA_HARDWARE_TYPE ]]; then
+        . /opt/utilities/bin/detect-hw-os
+        . /etc/environment.local
+    fi
+end script

--- a/init/arduino-uart-enable.conf
+++ b/init/arduino-uart-enable.conf
@@ -11,12 +11,13 @@ script
     fi
     if [ ! -c /dev/ttyO$ARDUINO_UART ] ; then
         . /etc/default/rcS
-        if [ "$NINJA_HARDWARE_TYPE" == "BBB" ]; then
+        . /etc/environment.local
+        if [ "$NINJA_HARDWARE_TYPE" = "BBB" ]; then
             capemgr=/sys/devices/bone_capemgr.9
             if [ ! -d $capemgr ] ; then
                 capemgr=/sys/devices/platform/bone_capemgr
             fi
-            exec echo "BB-UART$ARDUINO_UART" > $capemgr/slots
+            /bin/echo BB-UART$ARDUINO_UART > $capemgr/slots
         fi
     fi
 end script
@@ -25,8 +26,8 @@ pre-start script
     if [ -f /etc/environment.local ]; then
         . /etc/environment.local
     fi
-    if [[ -z $NINJA_HARDWARE_TYPE ]]; then
-        . /opt/utilities/bin/detect-hw-os
+    if [ -z "$NINJA_HARDWARE_TYPE" ]; then
+        /opt/utilities/bin/detect-hw-os
         . /etc/environment.local
     fi
 end script

--- a/setup_scripts/beagle_setup.sh
+++ b/setup_scripts/beagle_setup.sh
@@ -78,11 +78,11 @@ cd /home/ubuntu/;
 
 # Checking out mjpeg-streamer
 echo -e "\n→ ${bold}Checking out mjpeg-streamer${normal}\n"; 
-svn co https://mjpg-streamer.svn.sourceforge.net/svnroot/mjpg-streamer mjpg-streamer;
+svn co https://svn.code.sf.net/p/mjpg-streamer/code/mjpg-streamer mjpg-streamer;
 
 # Entering the mjpeg-streamer dir
 echo -e "\n→ ${bold}Entering the mjpeg-streamer dir${normal}\n"; 
-cd /home/ubuntu/mjpg-streamer/mjpg-streamer/;
+cd /home/ubuntu/mjpg-streamer/;
 
 # Making mjpeg-streamer
 echo -e "\n→ ${bold}Making mjpeg-streamer${normal}\n"; 
@@ -90,15 +90,15 @@ sudo make;
 
 # Copying input_uvc.so into place
 echo -e "\n→ ${bold}Copying input_uvc.so into place${normal}\n"; 
-sudo cp /home/ubuntu/mjpg-streamer/mjpg-streamer/input_uvc.so /usr/local/lib/;
+sudo cp /home/ubuntu/mjpg-streamer/input_uvc.so /usr/local/lib/;
 
 # Copying output_http.so into place
 echo -e "\n→ ${bold}Copying output_http.so into place${normal}\n"; 
-sudo cp /home/ubuntu/mjpg-streamer/mjpg-streamer/output_http.so /usr/local/lib/;
+sudo cp /home/ubuntu/mjpg-streamer/output_http.so /usr/local/lib/;
 
 # Copying the mjpg-streamer binary into /usr/bin
 echo -e "\n→ ${bold}Copying the mjpg-streamer binary into /usr/bin${normal}\n"; 
-sudo cp /home/ubuntu/mjpg-streamer/mjpg-streamer/mjpg_streamer /usr/local/bin;
+sudo cp /home/ubuntu/mjpg-streamer/mjpg_streamer /usr/local/bin;
 
 # Not essential packages
 echo -e "\n→ ${bold}Installing aptitude${normal}\n"; 


### PR DESCRIPTION
Newer images and/or kernels than those available from the Ninjablock stock may not have the additional UARTs enabled by default. They can, however, easily be enabled at runtime.
