### PR TITLE
Enable UART for Arduino communication

### DIFF
--- a/bin/enable_uart
+++ b/bin/enable_uart
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Enable the UART used for communicating with the Arduino board. On stock
+# images and newer kernels, this may not be enabled by default. One way to
+# enable it is through the boot command line (in /boot/uboot/uEnv.txt), but
+# it can be easily enough enabled at runtime as well.
+#
+# Author: Hilmar Lapp <hlapp@drycafe.net>
+
+if [[ $EUID -ne 0 ]]; then
+    echo "You must run this as root" 2>&1
+    exit 1
+fi
+
+if [ -f /etc/environment.local ]; then
+    . /etc/environment.local
+fi
+if [ -z "$NINJA_HARDWARE_TYPE" ]; then
+    . /opt/utilities/bin/detect-hw-os
+    . /etc/environment.local
+fi
+
+# We allow the number of the ttyO device to be set in the environment file.
+# It should nearly universally be ttyO1, though.
+if [ -z "$ARDUINO_UART" ] ; then
+    ARDUINO_UART=1
+fi
+
+# attempt to enable the ttyON device if it doesn't exist yet
+if [ ! -c /dev/ttyO$ARDUINO_UART ] ; then
+    capemgr=/sys/devices/bone_capemgr.9
+    if [ ! -d $capemgr ] ; then
+        capemgr=/sys/devices/platform/bone_capemgr
+    fi
+    echo BB-UART$ARDUINO_UART > $capemgr/slots
+    result=$?
+    if [ $result -ne 0 ] ; then
+        echo "unable to enable UART$ARDUINO_UART as device /dev/ttyO$ARDUINO_UART"
+        exit $result
+    fi
+fi

--- a/init/arduino-uart-enable.conf
+++ b/init/arduino-uart-enable.conf
@@ -6,28 +6,5 @@ start on filesystem and runlevel [2345]
 task
 
 script
-    if [ -z "$ARDUINO_UART" ] ; then
-        ARDUINO_UART=1
-    fi
-    if [ ! -c /dev/ttyO$ARDUINO_UART ] ; then
-        . /etc/default/rcS
-        . /etc/environment.local
-        if [ "$NINJA_HARDWARE_TYPE" = "BBB" ]; then
-            capemgr=/sys/devices/bone_capemgr.9
-            if [ ! -d $capemgr ] ; then
-                capemgr=/sys/devices/platform/bone_capemgr
-            fi
-            /bin/echo BB-UART$ARDUINO_UART > $capemgr/slots
-        fi
-    fi
-end script
-
-pre-start script
-    if [ -f /etc/environment.local ]; then
-        . /etc/environment.local
-    fi
-    if [ -z "$NINJA_HARDWARE_TYPE" ]; then
-        /opt/utilities/bin/detect-hw-os
-        . /etc/environment.local
-    fi
+    exec /opt/utilities/bin/enable_uart
 end script

--- a/init/arduino-uart-enable.conf
+++ b/init/arduino-uart-enable.conf
@@ -1,0 +1,32 @@
+description	"Ensure needed UARTs are enabled"
+author      "Hilmar Lapp <hlapp@drycafe.net>"
+
+start on filesystem and runlevel [2345]
+
+task
+
+script
+    if [ -z "$ARDUINO_UART" ] ; then
+        ARDUINO_UART=1
+    fi
+    if [ ! -c /dev/ttyO$ARDUINO_UART ] ; then
+        . /etc/default/rcS
+        if [ "$NINJA_HARDWARE_TYPE" == "BBB" ]; then
+            capemgr=/sys/devices/bone_capemgr.9
+            if [ ! -d $capemgr ] ; then
+                capemgr=/sys/devices/platform/bone_capemgr
+            fi
+            exec echo "BB-UART$ARDUINO_UART" > $capemgr/slots
+        fi
+    fi
+end script
+
+pre-start script
+    if [ -f /etc/environment.local ]; then
+        . /etc/environment.local
+    fi
+    if [[ -z $NINJA_HARDWARE_TYPE ]]; then
+        . /opt/utilities/bin/detect-hw-os
+        . /etc/environment.local
+    fi
+end script

--- a/init/arduino-uart-enable.conf
+++ b/init/arduino-uart-enable.conf
@@ -11,12 +11,13 @@ script
     fi
     if [ ! -c /dev/ttyO$ARDUINO_UART ] ; then
         . /etc/default/rcS
-        if [ "$NINJA_HARDWARE_TYPE" == "BBB" ]; then
+        . /etc/environment.local
+        if [ "$NINJA_HARDWARE_TYPE" = "BBB" ]; then
             capemgr=/sys/devices/bone_capemgr.9
             if [ ! -d $capemgr ] ; then
                 capemgr=/sys/devices/platform/bone_capemgr
             fi
-            exec echo "BB-UART$ARDUINO_UART" > $capemgr/slots
+            /bin/echo BB-UART$ARDUINO_UART > $capemgr/slots
         fi
     fi
 end script
@@ -25,8 +26,8 @@ pre-start script
     if [ -f /etc/environment.local ]; then
         . /etc/environment.local
     fi
-    if [[ -z $NINJA_HARDWARE_TYPE ]]; then
-        . /opt/utilities/bin/detect-hw-os
+    if [ -z "$NINJA_HARDWARE_TYPE" ]; then
+        /opt/utilities/bin/detect-hw-os
         . /etc/environment.local
     fi
 end script


### PR DESCRIPTION
Newer images and/or kernels than those available from the Ninjablock stock may not have the additional UARTs enabled by default. They can, however, easily be enabled at runtime.
