### PR TITLE
Fixes for setgpio script to avoid resource busy errors

### DIFF
--- a/bin/setgpio
+++ b/bin/setgpio
@@ -12,15 +12,17 @@ if [[ -n $NINJA_HARDWARE_TYPE ]]; then
                 echo -e "\x07" > /sys/kernel/debug/omap_mux/gpmc_ad6
         fi
         if [ "$NINJA_HARDWARE_TYPE" == "BBB" ] || [ "$NINJA_HARDWARE_TYPE" == "BBW" ]; then
-                echo "$NINJA_CAPE_DETECT_GPIO" > /sys/class/gpio/export;
-                if [[ -n $NINJA_CAPE_V11V12_RESETGPIO ]]; then
+                if [ ! -d /sys/class/gpio/gpio$NINJA_CAPE_DETECT_GPIO ] ; then
+                         echo "$NINJA_CAPE_DETECT_GPIO" > /sys/class/gpio/export;
+                fi
+                if [ -n "$NINJA_CAPE_V11V12_RESETGPIO" ] && [ ! -d /sys/class/gpio/gpio$NINJA_CAPE_V11V12_RESETGPIO ] ; then
                         echo "$NINJA_CAPE_V11V12_RESETGPIO" > /sys/class/gpio/export;
                 fi
-                if [[ -n $NINJA_CAPE_V121_RESETGPIO ]]; then
+                if [ -n "$NINJA_CAPE_V121_RESETGPIO" ] && [ ! -d /sys/class/gpio/gpio$NINJA_CAPE_V121_RESETGPIO ] ; then
                         echo "$NINJA_CAPE_V121_RESETGPIO" > /sys/class/gpio/export;
                 fi
         elif [ "$NINJA_HARDWARE_TYPE" == "RPI" ]; then
-                if [[ -n $NINJA_CRUST_V10_RESETGPIO ]]; then
+                if [ -n "$NINJA_CRUST_V10_RESETGPIO" ] && [ ! -d /sys/class/gpio/gpio$NINJA_CRUST_V10_RESETGPIO ] ; then
                         echo "$NINJA_CRUST_V10_RESETGPIO" > /sys/class/gpio/export;
                 fi
         fi

--- a/bin/setgpio
+++ b/bin/setgpio
@@ -12,33 +12,33 @@ if [[ -n $NINJA_HARDWARE_TYPE ]]; then
                 echo -e "\x07" > /sys/kernel/debug/omap_mux/gpmc_ad6
         fi
         if [ "$NINJA_HARDWARE_TYPE" == "BBB" ] || [ "$NINJA_HARDWARE_TYPE" == "BBW" ]; then
-                sudo echo "$NINJA_CAPE_DETECT_GPIO" > /sys/class/gpio/export;
+                echo "$NINJA_CAPE_DETECT_GPIO" > /sys/class/gpio/export;
                 if [[ -n $NINJA_CAPE_V11V12_RESETGPIO ]]; then
-                        sudo echo "$NINJA_CAPE_V11V12_RESETGPIO" > /sys/class/gpio/export;
+                        echo "$NINJA_CAPE_V11V12_RESETGPIO" > /sys/class/gpio/export;
                 fi
                 if [[ -n $NINJA_CAPE_V121_RESETGPIO ]]; then
-                        sudo echo "$NINJA_CAPE_V121_RESETGPIO" > /sys/class/gpio/export;
+                        echo "$NINJA_CAPE_V121_RESETGPIO" > /sys/class/gpio/export;
                 fi
         elif [ "$NINJA_HARDWARE_TYPE" == "RPI" ]; then
                 if [[ -n $NINJA_CRUST_V10_RESETGPIO ]]; then
-                        sudo echo "$NINJA_CRUST_V10_RESETGPIO" > /sys/class/gpio/export;
+                        echo "$NINJA_CRUST_V10_RESETGPIO" > /sys/class/gpio/export;
                 fi
         fi
         sleep 1;
         if [ "$NINJA_HARDWARE_TYPE" == "BBB" ] || [ "$NINJA_HARDWARE_TYPE" == "BBW" ]; then
-                sudo echo "in" > /sys/class/gpio/gpio$NINJA_CAPE_DETECT_GPIO/direction;
+                echo "in" > /sys/class/gpio/gpio$NINJA_CAPE_DETECT_GPIO/direction;
                 if [[ -n $NINJA_CAPE_V11V12_RESETGPIO ]]; then
-                        sudo echo "out" > /sys/class/gpio/gpio$NINJA_CAPE_V11V12_RESETGPIO/direction;
-                        sudo chown -R ubuntu /sys/class/gpio/gpio$NINJA_CAPE_V11V12_RESETGPIO/value
+                        echo "out" > /sys/class/gpio/gpio$NINJA_CAPE_V11V12_RESETGPIO/direction;
+                        chown -R ubuntu /sys/class/gpio/gpio$NINJA_CAPE_V11V12_RESETGPIO/value
                 fi
                 if [[ -n $NINJA_CAPE_V121_RESETGPIO ]]; then
-                        sudo echo "out" > /sys/class/gpio/gpio$NINJA_CAPE_V121_RESETGPIO/direction;
-                        sudo chown -R ubuntu /sys/class/gpio/gpio$NINJA_CAPE_V121_RESETGPIO/value
+                        echo "out" > /sys/class/gpio/gpio$NINJA_CAPE_V121_RESETGPIO/direction;
+                        chown -R ubuntu /sys/class/gpio/gpio$NINJA_CAPE_V121_RESETGPIO/value
                 fi
         elif [ "$NINJA_HARDWARE_TYPE" == "RPI" ]; then
                 if [[ -n $NINJA_CRUST_V10_RESETGPIO ]]; then
-                        sudo echo "out" > /sys/class/gpio/gpio$NINJA_CRUST_V10_RESETGPIO/direction;
-                        sudo chown -R pi /sys/class/gpio/gpio$NINJA_CRUST_V10_RESETGPIO/value
+                        echo "out" > /sys/class/gpio/gpio$NINJA_CRUST_V10_RESETGPIO/direction;
+                        chown -R pi /sys/class/gpio/gpio$NINJA_CRUST_V10_RESETGPIO/value
                 fi
         fi
 fi


### PR DESCRIPTION
This script is run every time the `/etc/init/ninjablock.conf` service is started. This will generate a resource busy write error if the GPIOs have already been exported the first time. The changes fix that.

Also removes the extraneous `sudo` prefixes. There is no point in running this not as root, so one might as well run the whole script as sudo. 
